### PR TITLE
add i8 support

### DIFF
--- a/result.go
+++ b/result.go
@@ -38,7 +38,7 @@ func getValue(parser *xml.Decoder) (result interface{}, err error) {
 				return getDateValue(parser)
 			case "double":
 				return getDoubleValue(parser)
-			case "int", "i4":
+			case "int", "i4", "i8":
 				return getIntValue(parser)
 			case "string":
 				return getStringValue(parser)


### PR DESCRIPTION
The application I'm interfacing with uses `i8` values for everything if it was compiled in 64bit mode. This is a very simple change that allows for correctly parsing them.
