### PR TITLE
add base64 support

### DIFF
--- a/request.go
+++ b/request.go
@@ -60,6 +60,9 @@ func buildValueElement(value interface{}) (buffer string) {
 	switch v := value.(type) {
 	case Struct:
 		buffer += buildStructElement(v)
+	case Base64:
+		escaped := escapeString(string(v))
+		buffer += fmt.Sprintf("<base64>%s</base64>", escaped)
 	case string:
 		escaped := escapeString(value.(string))
 		buffer += fmt.Sprintf("<string>%s</string>", escaped)

--- a/result.go
+++ b/result.go
@@ -40,6 +40,8 @@ func getValue(parser *xml.Decoder) (result interface{}, err error) {
 				return getDoubleValue(parser)
 			case "int", "i4", "i8":
 				return getIntValue(parser)
+			case "base64":
+				return getBase64Value(parser)
 			case "string":
 				return getStringValue(parser)
 			case "struct":
@@ -103,6 +105,10 @@ func getIntValue(parser *xml.Decoder) (interface{}, error) {
 	number, err := strconv.ParseInt(value, 0, 64)
 
 	return number, err
+}
+
+func getBase64Value(parser *xml.Decoder) (string, error) {
+	return getElementValue(parser)
 }
 
 func getStringValue(parser *xml.Decoder) (string, error) {

--- a/result_test.go
+++ b/result_test.go
@@ -21,6 +21,11 @@ func Test_parseValue_Int(t *testing.T) {
 }
 
 func Test_parseValue_String(t *testing.T) {
+	result, _ := parseValue([]byte("<value><base64>SGVsbG8sIHdvcmxkIQ==</base64></value>"))
+	assert_equal(t, "Hello, world!", result)
+}
+
+func Test_parseValue_Base64(t *testing.T) {
 	result, _ := parseValue([]byte("<value><string>Hello, world!</string></value>"))
 	assert_equal(t, "Hello, world!", result)
 }

--- a/xmlrpc.go
+++ b/xmlrpc.go
@@ -7,6 +7,9 @@ import (
 // Struct presents hash type used in xmlprc requests and responses.
 type Struct map[string]interface{}
 
+// Base64 represents base64 data
+type Base64 string
+
 // Params represents a list of parameters to a method.
 type Params struct {
 	Params []interface{}


### PR DESCRIPTION
The project I'm working on involves an application that accepts raw file data encoded in base64. Other xmlrpc libraries I've used such as ruby's ([from its standard library](https://github.com/ruby/ruby/blob/4c2304f0004e9f1784540f3d36976aad9eab1f68/lib/xmlrpc/parser.rb#L443)) have support for base64. This PR adds support for it to this library.

I've used it in the project I'm working on and works well, it's pretty much just like the string tag, but I needed to create a type synonym in order to type check against it, so base64 is sent like:

``` go
client.Call("some_func", xmlrpc.Base64(base64data), &result)
```
