### PR TITLE
Fix for Test_failedResponse test

### DIFF
--- a/response_test.go
+++ b/response_test.go
@@ -34,7 +34,7 @@ func Test_failedResponse(t *testing.T) {
 		t.Fatal("Failed() error: expected true, got false")
 	}
 
-	if resp.Err == nil {
+	if resp.Err() == nil {
 		t.Fatal("Err() error: expected error, got nil")
 	}
 


### PR DESCRIPTION
`$ go vet ./...
response_test.go:37: comparison of function Err == nil is always false`
