### PR TITLE
Make sure to encode time in UTC

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -37,7 +37,7 @@ func encodeValue(val reflect.Value) ([]byte, error) {
 		switch val.Interface().(type) {
 		case time.Time:
 			t := val.Interface().(time.Time)
-			b = []byte(fmt.Sprintf("<dateTime.iso8601>%s</dateTime.iso8601>", t.Format(iso8601)))
+			b = []byte(fmt.Sprintf("<dateTime.iso8601>%s</dateTime.iso8601>", t.UTC().Format(iso8601)))
 		default:
 			b, err = encodeStruct(val)
 		}


### PR DESCRIPTION
Currently, a time.Time value is encoded directly but the resulting iso8601 format string does not include a time zone, resulting in the time being interpreted in UTC (while it's not necessarily so).
