### PR TITLE
Use go-charset to decode non-UTF-8 responses

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -10,6 +10,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"code.google.com/p/go-charset/charset"
+	_ "code.google.com/p/go-charset/data"
 )
 
 const iso8601 = "20060102T15:04:05"
@@ -29,6 +32,8 @@ type decoder struct {
 
 func unmarshal(data []byte, v interface{}) (err error) {
 	dec := &decoder{xml.NewDecoder(bytes.NewBuffer(data))}
+
+	dec.CharsetReader = charset.NewReader
 
 	var tok xml.Token
 	for {


### PR DESCRIPTION
Hi, I have added decoding of non-UTF-8 responses using [go-charset](https://code.google.com/p/go-charset/). 

This patch works for me for decoding ISO-8859-1 encoded XML. The downside is that this pulls in a dependency that's not in the Go standard library. 