### PR TITLE
xmlrpc: Fix concurrent writes panic

### DIFF
--- a/client.go
+++ b/client.go
@@ -97,7 +97,9 @@ func (codec *clientCodec) ReadResponseHeader(response *rpc.Response) (err error)
 	codec.response = resp
 
 	response.Seq = seq
+	codec.responsesMu.Lock()
 	delete(codec.responses, seq)
+	codec.responsesMu.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
ClientCodecs WriteRequest method "must be safe for concurrent use by multiple
goroutines", as specified in net/rpc's documentation.

Starting from Go 1.5, the runtime panics if it detects concurrent writes to a
map.

This commit serializes writes to the responses map to ensure that the program
does not panic in the case when two xmlrpc requests are sent out simultaneously.
