### PR TITLE
Add Basic Authentication (and options argument for extensibility)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,22 @@ statement.
 
 ## Usage
 
-    client, _ := xmlrpc.NewClient("https://bugzilla.mozilla.org/xmlrpc.cgi", nil)
+    client, _ := xmlrpc.NewClient("https://bugzilla.mozilla.org/xmlrpc.cgi")
     result := struct{
       Version string `xmlrpc:"version"`
     }{}
     client.Call("Bugzilla.version", nil, &result)
     fmt.Printf("Version: %s\n", result.Version) // Version: 4.2.7+
 
-Second argument of NewClient function is an object that implements
-[http.RoundTripper](http://golang.org/pkg/net/http/#RoundTripper)
-interface, it can be used to get more control over connection options.
-By default it initialized by http.DefaultTransport object.
+
+Optionally, you may provide the following options after the URL argument in NewClient:
+
+* xmlrpc.BasicAuth(username, password string) - The credentials are passed in
+the Authorization HTTP request header per
+[RFC1945](https://tools.ietf.org/html/rfc1945#section-11.1).
+* xmlrpc.Transport([http.RoundTripper](http://golang.org/pkg/net/http/#RoundTripper)) -
+The RoundTripper interface can be used to get more control over connection
+options. By default it initialized by http.DefaultTransport object.
 
 ### Arguments encoding
 
@@ -28,6 +33,7 @@ xmlrpc package supports encoding of native Go data types to method
 arguments.
 
 Data types encoding rules:
+
 * int, int8, int16, int32, int64 encoded to int;
 * float32, float64 encoded to double;
 * bool encoded to boolean;
@@ -37,6 +43,7 @@ Data types encoding rules:
 * slice decoded to array;
 
 Structs decoded to struct by following rules:
+
 * all public field become struct members;
 * field name become member name;
 * if field has xmlrpc tag, its value become member name.
@@ -50,6 +57,7 @@ Each value of such slice encoded as separate argument.
 Result of remote function is decoded to native Go data type.
 
 Data types decoding rules:
+
 * int, i4 decoded to int, int8, int16, int32, int64;
 * double decoded to float32, float64;
 * boolean decoded to bool;
@@ -61,7 +69,8 @@ Data types decoding rules:
 
 ## Implementation details
 
-xmlrpc package contains clientCodec type, that implements [rpc.ClientCodec](http://golang.org/pkg/net/rpc/#ClientCodec)
+xmlrpc package contains clientCodec type, that implements
+[rpc.ClientCodec](http://golang.org/pkg/net/rpc/#ClientCodec)
 interface of [net/rpc](http://golang.org/pkg/net/rpc) package.
 
 xmlrpc package works over HTTP protocol, but some internal functions

--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"net/http/cookiejar"
 	"net/rpc"
 	"net/url"
+	"sync"
 )
 
 type Client struct {
@@ -21,9 +22,13 @@ type clientCodec struct {
 	// httpClient works with HTTP protocol
 	httpClient *http.Client
 
+	// creds allows HTTP requests to include credentials
+	creds Credentials
+
 	// cookies stores cookies received on last request
 	cookies http.CookieJar
 
+	resMutex sync.Mutex // protects responses
 	// responses presents map of active requests. It is required to return request id, that
 	// rpc.Client can mark them as done.
 	responses map[uint64]*http.Response
@@ -34,8 +39,47 @@ type clientCodec struct {
 	ready chan uint64
 }
 
+// Credentials handle adding credentials to a request.
+type Credentials interface {
+	SetCredentials(request *http.Request)
+}
+
+// A ClientOption sets options.
+type ClientOption func(*clientCodec)
+
+// Transport specifics a specific RoundTripper instead of http.DefaultTransport.
+func Transport(transport http.RoundTripper) ClientOption {
+	return func(codec *clientCodec) {
+		codec.httpClient = &http.Client{Transport: transport}
+	}
+}
+
+type basicAuth struct {
+	username string
+	password string
+}
+
+// SetCredentials sets the basic auth username and password.
+func (a *basicAuth) SetCredentials(request *http.Request) {
+	request.SetBasicAuth(a.username, a.password)
+}
+
+// BasicAuth sets the credentials for basic authentication.
+func BasicAuth(username, password string) ClientOption {
+	return func(codec *clientCodec) {
+		codec.creds = &basicAuth{
+			username: username,
+			password: password,
+		}
+	}
+}
+
 func (codec *clientCodec) WriteRequest(request *rpc.Request, args interface{}) (err error) {
 	httpRequest, err := NewRequest(codec.url.String(), request.ServiceMethod, args)
+
+	if codec.creds != nil {
+		codec.creds.SetCredentials(httpRequest)
+	}
 
 	if codec.cookies != nil {
 		for _, cookie := range codec.cookies.Cookies(codec.url) {
@@ -58,7 +102,9 @@ func (codec *clientCodec) WriteRequest(request *rpc.Request, args interface{}) (
 		codec.cookies.SetCookies(codec.url, httpResponse.Cookies())
 	}
 
+	codec.resMutex.Lock()
 	codec.responses[request.Seq] = httpResponse
+	codec.resMutex.Unlock()
 	codec.ready <- request.Seq
 
 	return nil
@@ -66,7 +112,10 @@ func (codec *clientCodec) WriteRequest(request *rpc.Request, args interface{}) (
 
 func (codec *clientCodec) ReadResponseHeader(response *rpc.Response) (err error) {
 	seq := <-codec.ready
+	codec.resMutex.Lock()
 	httpResponse := codec.responses[seq]
+	delete(codec.responses, seq)
+	codec.resMutex.Unlock()
 
 	if httpResponse.StatusCode < 200 || httpResponse.StatusCode >= 300 {
 		return fmt.Errorf("request error: bad status code - %d", httpResponse.StatusCode)
@@ -87,9 +136,7 @@ func (codec *clientCodec) ReadResponseHeader(response *rpc.Response) (err error)
 	}
 
 	codec.response = resp
-
 	response.Seq = seq
-	delete(codec.responses, seq)
 
 	return nil
 }
@@ -113,13 +160,7 @@ func (codec *clientCodec) Close() error {
 }
 
 // NewClient returns instance of rpc.Client object, that is used to send request to xmlrpc service.
-func NewClient(requrl string, transport http.RoundTripper) (*Client, error) {
-	if transport == nil {
-		transport = http.DefaultTransport
-	}
-
-	httpClient := &http.Client{Transport: transport}
-
+func NewClient(requrl string, opt ...ClientOption) (*Client, error) {
 	jar, err := cookiejar.New(nil)
 
 	if err != nil {
@@ -133,11 +174,20 @@ func NewClient(requrl string, transport http.RoundTripper) (*Client, error) {
 	}
 
 	codec := clientCodec{
-		url:        u,
-		httpClient: httpClient,
-		ready:      make(chan uint64),
-		responses:  make(map[uint64]*http.Response),
-		cookies:    jar,
+		url:       u,
+		ready:     make(chan uint64),
+		responses: make(map[uint64]*http.Response),
+		cookies:   jar,
+	}
+
+	for _, o := range opt {
+		if o != nil {
+			o(&codec)
+		}
+	}
+
+	if codec.httpClient == nil {
+		codec.httpClient = &http.Client{Transport: http.DefaultTransport}
 	}
 
 	return &Client{rpc.NewClientWithCodec(&codec)}, nil

--- a/client_test.go
+++ b/client_test.go
@@ -70,7 +70,7 @@ func Test_FailedCall(t *testing.T) {
 }
 
 func newClient(t *testing.T) *Client {
-	client, err := NewClient("http://localhost:5001", nil)
+	client, err := NewClient("http://localhost:5001")
 	if err != nil {
 		t.Fatalf("Can't create client: %v", err)
 	}


### PR DESCRIPTION
I need Basic Authentication for my use case and I read that it is not recommended to use RoundTripper to handle things like authentication headers, etc.  Here is a snippet from the Golang documentation.

> RoundTrip should not attempt to handle higher-level protocol details such as redirects, authentication, or cookies.

An options argument seems to be a common pattern for this scenario and feels a bit cleaner.  I also added a mutex around the responses map as it seems like that could be accessed by `client.Call / WriteRequest` and the internal `client.input / ReadResponseHeader` functions concurrently.