### PR TITLE
Mark client tests as integration

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package xmlrpc
 
 import (


### PR DESCRIPTION
# What?

Run client tests only if `integration` tag is set.