### PR TITLE
Format float using no exponent

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -51,7 +51,7 @@ func encodeValue(val reflect.Value) ([]byte, error) {
 		b = []byte(fmt.Sprintf("<i4>%s</i4>", strconv.FormatUint(val.Uint(), 10)))
 	case reflect.Float32, reflect.Float64:
 		b = []byte(fmt.Sprintf("<double>%s</double>",
-			strconv.FormatFloat(val.Float(), 'g', -1, val.Type().Bits())))
+			strconv.FormatFloat(val.Float(), 'f', -1, val.Type().Bits())))
 	case reflect.Bool:
 		if val.Bool() {
 			b = []byte("<boolean>1</boolean>")

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -17,6 +17,7 @@ var marshalTests = []struct {
 	{false, "<value><boolean>0</boolean></value>"},
 	{12.134, "<value><double>12.134</double></value>"},
 	{-12.134, "<value><double>-12.134</double></value>"},
+	{738777323.0, "<value><double>738777323</double></value>"},
 	{time.Unix(1386622812, 0).UTC(), "<value><dateTime.iso8601>20131209T21:00:12</dateTime.iso8601></value>"},
 	{[]interface{}{1, "one"}, "<value><array><data><value><int>1</int></value><value><string>one</string></value></data></array></value>"},
 	{&struct {


### PR DESCRIPTION
At the moment when encoding a `float32` or `float64` value, the library uses exponent format, converting number `738777323` to `7.38777323e+08`.

Considering that not all programming languages deal perfectly with exponent notation, this PR changes the format to `f` which means no exponent, improving compatibility with other systems.
