### PR TITLE
Sort map keys so output is deterministic

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 	"time"
 )
@@ -109,6 +110,12 @@ func encodeStruct(val reflect.Value) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
+type byStringValue []reflect.Value
+
+func (s byStringValue) Len() int           { return len(s) }
+func (s byStringValue) Less(i, j int) bool { return s[i].String() < s[j].String() }
+func (s byStringValue) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
 func encodeMap(val reflect.Value) ([]byte, error) {
 	var t = val.Type()
 
@@ -121,6 +128,7 @@ func encodeMap(val reflect.Value) ([]byte, error) {
 	b.WriteString("<struct>")
 
 	keys := val.MapKeys()
+	sort.Sort(byStringValue(keys))
 
 	for i := 0; i < val.Len(); i++ {
 		key := keys[i]

--- a/encoder.go
+++ b/encoder.go
@@ -110,12 +110,6 @@ func encodeStruct(val reflect.Value) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-type byStringValue []reflect.Value
-
-func (s byStringValue) Len() int           { return len(s) }
-func (s byStringValue) Less(i, j int) bool { return s[i].String() < s[j].String() }
-func (s byStringValue) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-
 func encodeMap(val reflect.Value) ([]byte, error) {
 	var t = val.Type()
 
@@ -128,7 +122,7 @@ func encodeMap(val reflect.Value) ([]byte, error) {
 	b.WriteString("<struct>")
 
 	keys := val.MapKeys()
-	sort.Sort(byStringValue(keys))
+	sort.Slice(keys, func(i, j int) bool { return keys[i].String() < keys[j].String() })
 
 	for i := 0; i < val.Len(); i++ {
 		key := keys[i]

--- a/encoder.go
+++ b/encoder.go
@@ -110,6 +110,8 @@ func encodeStruct(val reflect.Value) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
+var sortMapKeys bool
+
 func encodeMap(val reflect.Value) ([]byte, error) {
 	var t = val.Type()
 
@@ -122,7 +124,10 @@ func encodeMap(val reflect.Value) ([]byte, error) {
 	b.WriteString("<struct>")
 
 	keys := val.MapKeys()
-	sort.Slice(keys, func(i, j int) bool { return keys[i].String() < keys[j].String() })
+
+	if sortMapKeys {
+		sort.Slice(keys, func(i, j int) bool { return keys[i].String() < keys[j].String() })
+	}
 
 	for i := 0; i < val.Len(); i++ {
 		key := keys[i]

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -41,6 +41,8 @@ var marshalTests = []struct {
 }
 
 func Test_marshal(t *testing.T) {
+	sortMapKeys = true
+
 	for _, tt := range marshalTests {
 		b, err := marshal(tt.value)
 		if err != nil {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -28,7 +28,7 @@ var marshalTests = []struct {
 	}{}, "<value><struct><member><name>value</name><value/></member></struct></value>"},
 	{
 		map[string]interface{}{"title": "War and Piece", "amount": 20},
-		"<value><struct><member><name>title</name><value><string>War and Piece</string></value></member><member><name>amount</name><value><int>20</int></value></member></struct></value>",
+		"<value><struct><member><name>amount</name><value><int>20</int></value></member><member><name>title</name><value><string>War and Piece</string></value></member></struct></value>",
 	},
 	{
 		map[string]interface{}{
@@ -36,7 +36,7 @@ var marshalTests = []struct {
 			"Age":   6,
 			"Wight": []float32{66.67, 100.5},
 			"Dates": map[string]interface{}{"Birth": time.Date(1829, time.November, 10, 23, 0, 0, 0, time.UTC), "Death": time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)}},
-		"<value><struct><member><name>Name</name><value><string>John Smith</string></value></member><member><name>Age</name><value><int>6</int></value></member><member><name>Wight</name><value><array><data><value><double>66.67</double></value><value><double>100.5</double></value></data></array></value></member><member><name>Dates</name><value><struct><member><name>Birth</name><value><dateTime.iso8601>18291110T23:00:00</dateTime.iso8601></value></member><member><name>Death</name><value><dateTime.iso8601>20091110T23:00:00</dateTime.iso8601></value></member></struct></value></member></struct></value>",
+		"<value><struct><member><name>Age</name><value><int>6</int></value></member><member><name>Dates</name><value><struct><member><name>Birth</name><value><dateTime.iso8601>18291110T23:00:00</dateTime.iso8601></value></member><member><name>Death</name><value><dateTime.iso8601>20091110T23:00:00</dateTime.iso8601></value></member></struct></value></member><member><name>Name</name><value><string>John Smith</string></value></member><member><name>Wight</name><value><array><data><value><double>66.67</double></value><value><double>100.5</double></value></data></array></value></member></struct></value>",
 	},
 }
 


### PR DESCRIPTION
Since map iteration order is randomised, the tests randomly pass/fail. This change sorts the map keys before encoding to keep the output deterministic. Now the test always pass.