### PR TITLE
client: Handle NewRequest errors before adding cookies

### DIFF
--- a/client.go
+++ b/client.go
@@ -43,14 +43,14 @@ type clientCodec struct {
 func (codec *clientCodec) WriteRequest(request *rpc.Request, args interface{}) (err error) {
 	httpRequest, err := NewRequest(codec.url.String(), request.ServiceMethod, args)
 
+	if err != nil {
+		return err
+	}
+
 	if codec.cookies != nil {
 		for _, cookie := range codec.cookies.Cookies(codec.url) {
 			httpRequest.AddCookie(cookie)
 		}
-	}
-
-	if err != nil {
-		return err
 	}
 
 	var httpResponse *http.Response


### PR DESCRIPTION
Previously WriteRequest attempted to add cookies to the httpRequest
instance even if an error happened and might have resulted in
httpRequest being nil which in turn caused a crash.
This patch moves the error handling before looping through the current
cookies to avoid this crash from happening.

Signed-off-by: Vinzenz Feenstra <evilissimo@gmail.com>