### PR TITLE
Fix array parsing when one element is without type identifier

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -63,6 +63,7 @@ var unmarshalTests = []struct {
 	{[]int{1, 5, 7}, new(*[]int), "<value><array><data><value><int>1</int></value><value><int>5</int></value><value><int>7</int></value></data></array></value>"},
 	{[]interface{}{"A", "5"}, new(interface{}), "<value><array><data><value><string>A</string></value><value><string>5</string></value></data></array></value>"},
 	{[]interface{}{"A", int64(5)}, new(interface{}), "<value><array><data><value><string>A</string></value><value><int>5</int></value></data></array></value>"},
+	{[]interface{}{int64(5), nil, "A"}, new(interface{}), "<value><array><data><value><int>5</int></value><value></value><value><string>A</string></value></data></array></value>"},
 
 	// struct
 	{book{"War and Piece", 20}, new(*book), "<value><struct><member><name>Title</name><value><string>War and Piece</string></value></member><member><name>Amount</name><value><int>20</int></value></member></struct></value>"},


### PR DESCRIPTION
Hello, i stumbled across a response that xmlrpc is unable to decode correctly:
```
<value><array><data>
  <value><int>5</int></value>
  <value></value>
  <value><string>A</string></value>
</data></array></value>
```

This is a 3-elements array containing respectively:
* an int
* a value without the type identifier, which according to the XML-RPC specification is acceptable (http://xmlrpc.scripting.com/spec.html), and is also normally handled by xmlrpc (https://github.com/kolo/xmlrpc/blob/master/decoder_test.go#L138)
* a string

The library decodes the XML into a 2-elements slice:
```
{ 5, nil }
```

I did some tests, and i discovered that, when decoding a slice, the library does not decode correctly the element immediately after an element without the type identifier. That's due to this sequence of events:
1. the slice decoder calls dec.Token() and reads a token (&lt;value>)
    https://github.com/kolo/xmlrpc/blob/master/decoder.go#L248

2. the slice decoder calls dec.decodeValue()
    https://github.com/kolo/xmlrpc/blob/master/decoder.go#L266

3. dec.decodeValue() calls dec.Token() and reads a token, expecting to find the starting tag of a type identifier (i.e. &lt;string>), but instead it finds &lt;/value>, and returns nil, since it's an EndElement
    https://github.com/kolo/xmlrpc/blob/master/decoder.go#L89

4. the slice decoder calls dec.Skip(), which normally should read any tag up to &lt;/value>, but since &lt;/value> has already been processed, it goes on and reads the next &lt;value>, &lt;string>, &lt;/string>, &lt;/value>, so the next array element is totally skipped:
    https://github.com/kolo/xmlrpc/blob/master/decoder.go#L278

This patch fixes the problem, by skipping dec.Skip() when this problem arises.
I also added a unit test.
