### PR TITLE
fix array parsing when one element is without type identifier and not null

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -106,11 +106,16 @@ func (dec *decoder) decodeValue(val reflect.Value) error {
 		// Treat value data without type identifier as string
 		if t, ok := tok.(xml.CharData); ok {
 			if value := strings.TrimSpace(string(t)); value != "" {
-				if err = checkType(val, reflect.String); err != nil {
+				if checkType(val, reflect.Interface) == nil && val.IsNil() {
+					pstr := reflect.New(reflect.TypeOf(value)).Elem()
+					pstr.SetString(value)
+					val.Set(pstr)
+				} else if err = checkType(val, reflect.String); err != nil {
 					return err
+				} else {
+					val.SetString(value)
 				}
 
-				val.SetString(value)
 				return nil
 			}
 		}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -60,6 +60,7 @@ var unmarshalTests = []struct {
 	{_time("2013-12-09T21:00:12+01:00"), new(*time.Time), "<value><dateTime.iso8601>2013-12-09T21:00:12+01:00</dateTime.iso8601></value>"},
 
 	// array
+	{[]interface{}{"A"}, new(interface{}), "<value><array><data><value>A</value></data></array></value>"},
 	{[]int{1, 5, 7}, new(*[]int), "<value><array><data><value><int>1</int></value><value><int>5</int></value><value><int>7</int></value></data></array></value>"},
 	{[]interface{}{"A", "5"}, new(interface{}), "<value><array><data><value><string>A</string></value><value><string>5</string></value></data></array></value>"},
 	{[]interface{}{"A", int64(5)}, new(interface{}), "<value><array><data><value><string>A</string></value><value><int>5</int></value></data></array></value>"},


### PR DESCRIPTION
Hello, this is another fix, unrelated to #67, that allows to parse this response:
```
<value><array><data>
  <value>A</value>
</data></array></value>
```
when using as receiver:
```
&[]interface{}{}
```

The problem here is that the library, when dealing with arrays, instantiates an object of the same type of the array for each element, so in this case it instantiates an `interface{}` for each element.

An `interface{}` can receive a string, but only if the type identifier is specified, ie:
```
<value><string>Once upon a time</string></value>
```

This patch allows an `interface{}` to receive a string even when the type identifier is absent, ie:
```
<value>Once upon a time</value>
```

PS: if you're wondering what kind of software/protocol is producing these horrendous responses, it's the Robot Operating System (ROS) (https://www.ros.org/)
