### PR TITLE
Adding omitempty support for struct Marshalling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Second argument of NewClient function is an object that implements
 [http.RoundTripper](http://golang.org/pkg/net/http/#RoundTripper)
 interface, it can be used to get more control over connection options.
 By default it initialized by http.DefaultTransport object.
+These tags support the omitempty property.
 
 ### Arguments encoding
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Second argument of NewClient function is an object that implements
 [http.RoundTripper](http://golang.org/pkg/net/http/#RoundTripper)
 interface, it can be used to get more control over connection options.
 By default it initialized by http.DefaultTransport object.
-These tags support the omitempty property.
 
 ### Arguments encoding
 
@@ -45,11 +44,12 @@ Data types encoding rules:
 * xmlrpc.Base64 encoded to base64;
 * slice encoded to array;
 
-Structs decoded to struct by following rules:
+Structs encoded to struct by following rules:
 
 * all public field become struct members;
 * field name become member name;
 * if field has xmlrpc tag, its value become member name.
+* for fields tagged with `",omitempty"`, empty values are omitted;
 
 Server method can accept few arguments, to handle this case there is
 special approach to handle slice of empty interfaces (`[]interface{}`).

--- a/encoder.go
+++ b/encoder.go
@@ -84,26 +84,27 @@ func encodeValue(val reflect.Value) ([]byte, error) {
 	return []byte(fmt.Sprintf("<value>%s</value>", string(b))), nil
 }
 
-func encodeStruct(val reflect.Value) ([]byte, error) {
+func encodeStruct(structVal reflect.Value) ([]byte, error) {
 	var b bytes.Buffer
 
 	b.WriteString("<struct>")
 
-	t := val.Type()
-	for i := 0; i < t.NumField(); i++ {
-		f := t.Field(i)
+	structType := structVal.Type()
+	for i := 0; i < structType.NumField(); i++ {
+		fieldVal := structVal.Field(i)
+		fieldType := structType.Field(i)
 
-		name := f.Tag.Get("xmlrpc")
+		name := fieldType.Tag.Get("xmlrpc")
 		// if the tag has the omitempty property, skip it
-		if strings.HasSuffix(name, ",omitempty") && val.FieldByName(f.Name).IsZero() {
+		if strings.HasSuffix(name, ",omitempty") && fieldVal.IsZero() {
 			continue
 		}
 		name = strings.TrimSuffix(name, ",omitempty")
 		if name == "" {
-			name = f.Name
+			name = fieldType.Name
 		}
 
-		p, err := encodeValue(val.FieldByName(f.Name))
+		p, err := encodeValue(fieldVal)
 		if err != nil {
 			return nil, err
 		}

--- a/encoder.go
+++ b/encoder.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -90,21 +91,25 @@ func encodeStruct(val reflect.Value) ([]byte, error) {
 
 	t := val.Type()
 	for i := 0; i < t.NumField(); i++ {
-		b.WriteString("<member>")
 		f := t.Field(i)
 
 		name := f.Tag.Get("xmlrpc")
+		// if the tag has the omitempty property, skip it
+		if strings.HasSuffix(name, ",omitempty") {
+			continue
+		}
 		if name == "" {
 			name = f.Name
 		}
-		b.WriteString(fmt.Sprintf("<name>%s</name>", name))
 
 		p, err := encodeValue(val.FieldByName(f.Name))
 		if err != nil {
 			return nil, err
 		}
-		b.Write(p)
 
+		b.WriteString("<member>")
+		b.WriteString(fmt.Sprintf("<name>%s</name>", name))
+		b.Write(p)
 		b.WriteString("</member>")
 	}
 

--- a/encoder.go
+++ b/encoder.go
@@ -95,9 +95,10 @@ func encodeStruct(val reflect.Value) ([]byte, error) {
 
 		name := f.Tag.Get("xmlrpc")
 		// if the tag has the omitempty property, skip it
-		if strings.HasSuffix(name, ",omitempty") {
+		if strings.HasSuffix(name, ",omitempty") && val.FieldByName(f.Name).IsZero() {
 			continue
 		}
+		name = strings.TrimSuffix(name, ",omitempty")
 		if name == "" {
 			name = f.Name
 		}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -39,6 +39,15 @@ var marshalTests = []struct {
 			"Dates": map[string]interface{}{"Birth": time.Date(1829, time.November, 10, 23, 0, 0, 0, time.UTC), "Death": time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)}},
 		"<value><struct><member><name>Age</name><value><int>6</int></value></member><member><name>Dates</name><value><struct><member><name>Birth</name><value><dateTime.iso8601>18291110T23:00:00</dateTime.iso8601></value></member><member><name>Death</name><value><dateTime.iso8601>20091110T23:00:00</dateTime.iso8601></value></member></struct></value></member><member><name>Name</name><value><string>John Smith</string></value></member><member><name>Wight</name><value><array><data><value><double>66.67</double></value><value><double>100.5</double></value></data></array></value></member></struct></value>",
 	},
+	{&struct {
+		Title  string
+		Amount int
+		Author string `xmlrpc:"author,omitempty"`
+	}{
+		Title: "War and Piece", Amount: 20, Author: "bob",
+	}, "<value><struct><member><name>Title</name><value><string>War and Piece</string></value></member><member><name>Amount</name><value><int>20</int></value></member></struct></value>"},
+	{&struct {
+	}{}, "<value><struct></struct></value>"},
 }
 
 func Test_marshal(t *testing.T) {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -44,8 +44,15 @@ var marshalTests = []struct {
 		Amount int
 		Author string `xmlrpc:"author,omitempty"`
 	}{
-		Title: "War and Piece", Amount: 20, Author: "bob",
+		Title: "War and Piece", Amount: 20,
 	}, "<value><struct><member><name>Title</name><value><string>War and Piece</string></value></member><member><name>Amount</name><value><int>20</int></value></member></struct></value>"},
+	{&struct {
+		Title  string
+		Amount int
+		Author string `xmlrpc:"author,omitempty"`
+	}{
+		Title: "War and Piece", Amount: 20, Author: "Leo Tolstoy",
+	}, "<value><struct><member><name>Title</name><value><string>War and Piece</string></value></member><member><name>Amount</name><value><int>20</int></value></member><member><name>author</name><value><string>Leo Tolstoy</string></value></member></struct></value>"},
 	{&struct {
 	}{}, "<value><struct></struct></value>"},
 }


### PR DESCRIPTION
I've modified the encoder to honor a tag of:

```
`xmlrpc:"tag,omitempty"`
```

This allows someone to skip sending values that are empty - as defined by `reflect.Value.IsZero()`.

Note, this may be a breaking change? If anyone has a struct with a tag of `something,omitempty` this will also strip `,omitempty` from the end of that tag and possibly not send it? I would expect this would be unintended behavior?

I also added a test to explicitly show what happens when you encode a empty struct:

```xml
<value><struct></struct></value>
```

I don't know if that's intended, and I didn't see anything in the XMLRPC spec about an empty `<struct>` element, so I don't know if that's right?