### PR TITLE
Support versions of Go < 1.13

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -96,7 +96,7 @@ func encodeStruct(structVal reflect.Value) ([]byte, error) {
 
 		name := fieldType.Tag.Get("xmlrpc")
 		// if the tag has the omitempty property, skip it
-		if strings.HasSuffix(name, ",omitempty") && fieldVal.IsZero() {
+		if strings.HasSuffix(name, ",omitempty") && isZero(fieldVal) {
 			continue
 		}
 		name = strings.TrimSuffix(name, ",omitempty")

--- a/is_zero.go
+++ b/is_zero.go
@@ -1,0 +1,44 @@
+package xmlrpc
+
+import (
+	"math"
+	. "reflect"
+)
+
+func isZero(v Value) bool {
+	switch v.Kind() {
+	case Bool:
+		return !v.Bool()
+	case Int, Int8, Int16, Int32, Int64:
+		return v.Int() == 0
+	case Uint, Uint8, Uint16, Uint32, Uint64, Uintptr:
+		return v.Uint() == 0
+	case Float32, Float64:
+		return math.Float64bits(v.Float()) == 0
+	case Complex64, Complex128:
+		c := v.Complex()
+		return math.Float64bits(real(c)) == 0 && math.Float64bits(imag(c)) == 0
+	case Array:
+		for i := 0; i < v.Len(); i++ {
+			if !isZero(v.Index(i)) {
+				return false
+			}
+		}
+		return true
+	case Chan, Func, Interface, Map, Ptr, Slice, UnsafePointer:
+		return v.IsNil()
+	case String:
+		return v.Len() == 0
+	case Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if !isZero(v.Field(i)) {
+				return false
+			}
+		}
+		return true
+	default:
+		// This should never happens, but will act as a safeguard for
+		// later, as a default value doesn't makes sense here.
+		panic(&ValueError{"reflect.Value.IsZero", v.Kind()})
+	}
+}


### PR DESCRIPTION
The `reflect.Value.IsZero` method was added in 1.13. This PR copies the implementation into the codebase.