### PR TITLE
Make 'decoder' and 'marshal' public

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -32,12 +32,12 @@ type TypeMismatchError string
 
 func (e TypeMismatchError) Error() string { return string(e) }
 
-type decoder struct {
+type Decoder struct {
 	*xml.Decoder
 }
 
 func unmarshal(data []byte, v interface{}) (err error) {
-	dec := &decoder{xml.NewDecoder(bytes.NewBuffer(data))}
+	dec := &Decoder{xml.NewDecoder(bytes.NewBuffer(data))}
 
 	if CharsetReader != nil {
 		dec.CharsetReader = CharsetReader
@@ -55,7 +55,7 @@ func unmarshal(data []byte, v interface{}) (err error) {
 				if val.Kind() != reflect.Ptr {
 					return errors.New("non-pointer value passed to unmarshal")
 				}
-				if err = dec.decodeValue(val.Elem()); err != nil {
+				if err = dec.DecodeValue(val.Elem()); err != nil {
 					return err
 				}
 
@@ -73,7 +73,7 @@ func unmarshal(data []byte, v interface{}) (err error) {
 	return nil
 }
 
-func (dec *decoder) decodeValue(val reflect.Value) error {
+func (dec *Decoder) DecodeValue(val reflect.Value) error {
 	var tok xml.Token
 	var err error
 
@@ -196,7 +196,7 @@ func (dec *decoder) decodeValue(val reflect.Value) error {
 							return err
 						}
 						if t, ok := tok.(xml.StartElement); ok && t.Name.Local == "value" {
-							if err = dec.decodeValue(fv); err != nil {
+							if err = dec.DecodeValue(fv); err != nil {
 								return err
 							}
 
@@ -263,12 +263,12 @@ func (dec *decoder) decodeValue(val reflect.Value) error {
 							if v.Kind() != reflect.Ptr {
 								return errors.New("error: cannot write to non-pointer array element")
 							}
-							if err = dec.decodeValue(v); err != nil {
+							if err = dec.DecodeValue(v); err != nil {
 								return err
 							}
 						} else {
 							v := reflect.New(slice.Type().Elem())
-							if err = dec.decodeValue(v); err != nil {
+							if err = dec.DecodeValue(v); err != nil {
 								return err
 							}
 							slice = reflect.Append(slice, v.Elem())
@@ -407,7 +407,7 @@ func (dec *decoder) decodeValue(val reflect.Value) error {
 	return nil
 }
 
-func (dec *decoder) readTag() (string, []byte, error) {
+func (dec *Decoder) readTag() (string, []byte, error) {
 	var tok xml.Token
 	var err error
 
@@ -431,7 +431,7 @@ func (dec *decoder) readTag() (string, []byte, error) {
 	return name, value, dec.Skip()
 }
 
-func (dec *decoder) readCharData() ([]byte, error) {
+func (dec *Decoder) readCharData() ([]byte, error) {
 	var tok xml.Token
 	var err error
 

--- a/encoder.go
+++ b/encoder.go
@@ -16,7 +16,7 @@ type Base64 string
 
 type encodeFunc func(reflect.Value) ([]byte, error)
 
-func marshal(v interface{}) ([]byte, error) {
+func Marshal(v interface{}) ([]byte, error) {
 	if v == nil {
 		return []byte{}, nil
 	}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -61,7 +61,7 @@ func Test_marshal(t *testing.T) {
 	sortMapKeys = true
 
 	for _, tt := range marshalTests {
-		b, err := marshal(tt.value)
+		b, err := Marshal(tt.value)
 		if err != nil {
 			t.Fatalf("unexpected marshal error: %v", err)
 		}

--- a/request.go
+++ b/request.go
@@ -40,7 +40,7 @@ func EncodeMethodCall(method string, args ...interface{}) ([]byte, error) {
 		b.WriteString("<params>")
 
 		for _, arg := range args {
-			p, err := marshal(arg)
+			p, err := Marshal(arg)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
The purpose of this PR is to make the 'decoder' and 'marshal' public so they can be extended.

A possible use case is extend the 'decoder' to unmarshal server request and make it possible to integrate the library with different servers, for example. For the same use case, making the 'marshal' function public is enough for encoding a server response.

I work for the Uyuni-project (https://github.com/uyuni-project) and in our side, we are integrating this library with Gorilla RPC(https://github.com/gorilla/rpc) to build an API gateway (https://github.com/uyuni-project/hub-xmlrpc-api).