### PR TITLE
Allow for nil tags

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -104,9 +104,21 @@ func encodeStruct(structVal reflect.Value) ([]byte, error) {
 			name = fieldType.Name
 		}
 
-		p, err := encodeValue(fieldVal)
-		if err != nil {
-			return nil, err
+		var p []byte
+		var err error
+		// if the tag has the nilTag property, write it as '<nil/>'
+		if strings.HasSuffix(name, ",nilTag") && fieldVal.IsNil() {
+			p, err = []byte("<value><nil/></value>"), nil
+
+			name = strings.TrimSuffix(name, ",nilTag")
+			if name == "" {
+				name = fieldType.Name
+			}
+		} else {
+			p, err = encodeValue(fieldVal)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		b.WriteString("<member>")


### PR DESCRIPTION
I added this patch in order to work with an API that presents xml with any empty nil tag (i.e. `<nil/>`) when the value of `foo` is nil, e.g.:

```
     <struct>
        <member>
          <name>foo</name>
          <value>
            <nil/>
          </value>
        </member>
     ...
    </struct>
```

To use this patch, the struct looks like below:

```
type Params struct {
    Foo  *string `xmlrpc:"foo",nilTag"`
    Bar string  `xmlrpc:"bar"`
}
```

Would a patch like this be appropriate for `kolo/xmlrpc`? Any suggestions on better ways to work with this sort of data would be much appreciated (mostly I just want to avoid maintaining a separate fork) :)